### PR TITLE
fix: update redistribution abi

### DIFF
--- a/abi/Redistribution.abi.json
+++ b/abi/Redistribution.abi.json
@@ -26,6 +26,19 @@
             {
                 "indexed": false,
                 "internalType": "uint256",
+                "name": "validChunkCount",
+                "type": "uint256"
+            }
+        ],
+        "name": "ChunkCount",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
                 "name": "roundNumber",
                 "type": "uint256"
             },
@@ -63,6 +76,25 @@
             }
         ],
         "name": "CountReveals",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "roundNumber",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "anchor",
+                "type": "bytes32"
+            }
+        ],
+        "name": "CurrentRevealAnchor",
         "type": "event"
     },
     {
@@ -898,6 +930,24 @@
             }
         ],
         "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_penaltyMultiplierDisagreement",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_penaltyMultiplierNonRevealed",
+                "type": "uint256"
+            }
+        ],
+        "name": "setFreezingParams",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
     },
     {


### PR DESCRIPTION
The ABI was updated for the new storage incentives version and thus broke the miner.